### PR TITLE
Fixes findBatch to support Rx

### DIFF
--- a/vertx-mongo-client/src/main/asciidoc/groovy/index.adoc
+++ b/vertx-mongo-client/src/main/asciidoc/groovy/index.adoc
@@ -453,27 +453,13 @@ def query = [
   author:"J. R. R. Tolkien"
 ]
 
-mongoClient.findBatch("book", query, { res ->
-
-  if (res.succeeded()) {
-
-    if (res.result() == null) {
-
-      println("End of research")
-
-    } else {
-
-      println("Found doc: ${groovy.json.JsonOutput.toJson(res.result())}")
-
-    }
-
-  } else {
-
-    res.cause().printStackTrace()
-
-  }
+mongoClient.findBatch("book", query).exceptionHandler({ throwable ->
+  throwable.printStackTrace()
+}).endHandler({ v ->
+  println("End of research")
+}).handler({ doc ->
+  println("Found doc: ${groovy.json.JsonOutput.toJson(doc)}")
 })
-
 
 ----
 
@@ -844,8 +830,8 @@ mongoClient.save("books", document, { res ->
 
   if (res.succeeded()) {
 
-    mongoClient.distinctBatch("books", "title", java.lang.String.class.getName(), { res2 ->
-      println("Title is : ${res2.result().title}")
+    mongoClient.distinctBatch("books", "title", java.lang.String.class.getName()).handler({ book ->
+      println("Title is : ${book.title}")
     })
 
   } else {
@@ -905,9 +891,10 @@ def query = [
 mongoClient.save("books", document, { res ->
   if (res.succeeded()) {
 
-    mongoClient.distinctBatchWithQuery("books", "title", java.lang.String.class.getName(), query, { res2 ->
-      println("Title is : ${res2.result().title}")
+    mongoClient.distinctBatchWithQuery("books", "title", java.lang.String.class.getName(), query).handler({ book ->
+      println("Title is : ${book.title}")
     })
+
   }
 
 })

--- a/vertx-mongo-client/src/main/asciidoc/java/index.adoc
+++ b/vertx-mongo-client/src/main/asciidoc/java/index.adoc
@@ -370,26 +370,10 @@ This has the following fields:
 ----
 JsonObject query = new JsonObject().put("author", "J. R. R. Tolkien");
 
-mongoClient.findBatch("book", query, res -> {
-
-  if (res.succeeded()) {
-
-    if (res.result() == null) {
-
-      System.out.println("End of research");
-
-    } else {
-
-      System.out.println("Found doc: " + res.result().encodePrettily());
-
-    }
-
-  } else {
-
-    res.cause().printStackTrace();
-
-  }
-});
+mongoClient.findBatch("book", query)
+  .exceptionHandler(throwable -> throwable.printStackTrace())
+  .endHandler(v -> System.out.println("End of research"))
+  .handler(doc -> System.out.println("Found doc: " + doc.encodePrettily()));
 ----
 
 The matching documents are returned unitary in the result handler.
@@ -706,9 +690,8 @@ mongoClient.save("books", document, res -> {
 
   if (res.succeeded()) {
 
-    mongoClient.distinctBatch("books", "title", String.class.getName(), res2 -> {
-      System.out.println("Title is : " + res2.result().getString("title"));
-    });
+    mongoClient.distinctBatch("books", "title", String.class.getName())
+      .handler(book -> System.out.println("Title is : " + book.getString("title")));
 
   } else {
     res.cause().printStackTrace();
@@ -749,9 +732,9 @@ JsonObject query = new JsonObject()
 mongoClient.save("books", document, res -> {
   if (res.succeeded()) {
 
-    mongoClient.distinctBatchWithQuery("books", "title", String.class.getName(), query, res2 -> {
-      System.out.println("Title is : " + res2.result().getString("title"));
-    });
+    mongoClient.distinctBatchWithQuery("books", "title", String.class.getName(), query)
+      .handler(book -> System.out.println("Title is : " + book.getString("title")));
+
   }
 
 });

--- a/vertx-mongo-client/src/main/asciidoc/js/index.adoc
+++ b/vertx-mongo-client/src/main/asciidoc/js/index.adoc
@@ -457,27 +457,13 @@ var query = {
   "author" : "J. R. R. Tolkien"
 };
 
-mongoClient.findBatch("book", query, function (res, res_err) {
-
-  if (res_err == null) {
-
-    if ((res === null || res === undefined)) {
-
-      console.log("End of research");
-
-    } else {
-
-      console.log("Found doc: " + JSON.stringify(res));
-
-    }
-
-  } else {
-
-    res_err.printStackTrace();
-
-  }
+mongoClient.findBatch("book", query).exceptionHandler(function (throwable) {
+  throwable.printStackTrace();
+}).endHandler(function (v) {
+  console.log("End of research");
+}).handler(function (doc) {
+  console.log("Found doc: " + JSON.stringify(doc));
 });
-
 
 ----
 
@@ -848,8 +834,8 @@ mongoClient.save("books", document, function (res, res_err) {
 
   if (res_err == null) {
 
-    mongoClient.distinctBatch("books", "title", Java.type("java.lang.String").class.getName(), function (res2, res2_err) {
-      console.log("Title is : " + res2.title);
+    mongoClient.distinctBatch("books", "title", Java.type("java.lang.String").class.getName()).handler(function (book) {
+      console.log("Title is : " + book.title);
     });
 
   } else {
@@ -909,9 +895,10 @@ var query = {
 mongoClient.save("books", document, function (res, res_err) {
   if (res_err == null) {
 
-    mongoClient.distinctBatchWithQuery("books", "title", Java.type("java.lang.String").class.getName(), query, function (res2, res2_err) {
-      console.log("Title is : " + res2.title);
+    mongoClient.distinctBatchWithQuery("books", "title", Java.type("java.lang.String").class.getName(), query).handler(function (book) {
+      console.log("Title is : " + book.title);
     });
+
   }
 
 });

--- a/vertx-mongo-client/src/main/asciidoc/kotlin/index.adoc
+++ b/vertx-mongo-client/src/main/asciidoc/kotlin/index.adoc
@@ -456,27 +456,13 @@ var query = json {
   obj("author" to "J. R. R. Tolkien")
 }
 
-mongoClient.findBatch("book", query, { res ->
-
-  if (res.succeeded()) {
-
-    if (res.result() == null) {
-
-      println("End of research")
-
-    } else {
-
-      println("Found doc: ${res.result().toString()}")
-
-    }
-
-  } else {
-
-    res.cause().printStackTrace()
-
-  }
+mongoClient.findBatch("book", query).exceptionHandler({ throwable ->
+  throwable.printStackTrace()
+}).endHandler({ v ->
+  println("End of research")
+}).handler({ doc ->
+  println("Found doc: ${doc.toString()}")
 })
-
 
 ----
 
@@ -848,8 +834,8 @@ mongoClient.save("books", document, { res ->
 
   if (res.succeeded()) {
 
-    mongoClient.distinctBatch("books", "title", String.`class`.getName(), { res2 ->
-      println("Title is : ${res2.result().getString("title")}")
+    mongoClient.distinctBatch("books", "title", String.`class`.getName()).handler({ book ->
+      println("Title is : ${book.getString("title")}")
     })
 
   } else {
@@ -901,9 +887,10 @@ var query = json {
 mongoClient.save("books", document, { res ->
   if (res.succeeded()) {
 
-    mongoClient.distinctBatchWithQuery("books", "title", String.`class`.getName(), query, { res2 ->
-      println("Title is : ${res2.result().getString("title")}")
+    mongoClient.distinctBatchWithQuery("books", "title", String.`class`.getName(), query).handler({ book ->
+      println("Title is : ${book.getString("title")}")
     })
+
   }
 
 })

--- a/vertx-mongo-client/src/main/asciidoc/ruby/index.adoc
+++ b/vertx-mongo-client/src/main/asciidoc/ruby/index.adoc
@@ -460,27 +460,13 @@ query = {
   'author' => "J. R. R. Tolkien"
 }
 
-mongoClient.find_batch("book", query) { |res_err,res|
-
-  if (res_err == nil)
-
-    if (res == nil)
-
-      puts "End of research"
-
-    else
-
-      puts "Found doc: #{JSON.generate(res)}"
-
-    end
-
-  else
-
-    res_err.print_stack_trace()
-
-  end
+mongoClient.find_batch("book", query).exception_handler() { |throwable|
+  throwable.print_stack_trace()
+}.end_handler() { |v|
+  puts "End of research"
+}.handler() { |doc|
+  puts "Found doc: #{JSON.generate(doc)}"
 }
-
 
 ----
 
@@ -851,8 +837,8 @@ mongoClient.save("books", document) { |res_err,res|
 
   if (res_err == nil)
 
-    mongoClient.distinct_batch("books", "title", Java::JavaLang::String::class.get_name()) { |res2_err,res2|
-      puts "Title is : #{res2['title']}"
+    mongoClient.distinct_batch("books", "title", Java::JavaLang::String::class.get_name()).handler() { |book|
+      puts "Title is : #{book['title']}"
     }
 
   else
@@ -912,9 +898,10 @@ query = {
 mongoClient.save("books", document) { |res_err,res|
   if (res_err == nil)
 
-    mongoClient.distinct_batch_with_query("books", "title", Java::JavaLang::String::class.get_name(), query) { |res2_err,res2|
-      puts "Title is : #{res2['title']}"
+    mongoClient.distinct_batch_with_query("books", "title", Java::JavaLang::String::class.get_name(), query).handler() { |book|
+      puts "Title is : #{book['title']}"
     }
+
   end
 
 }

--- a/vertx-mongo-client/src/main/java/examples/Examples.java
+++ b/vertx-mongo-client/src/main/java/examples/Examples.java
@@ -259,27 +259,10 @@ public class Examples {
     // will match all Tolkien books
     JsonObject query = new JsonObject().put("author", "J. R. R. Tolkien");
 
-    mongoClient.findBatch("book", query, res -> {
-
-      if (res.succeeded()) {
-
-        if (res.result() == null) {
-
-          System.out.println("End of research");
-
-        } else {
-
-          System.out.println("Found doc: " + res.result().encodePrettily());
-
-        }
-
-      } else {
-
-        res.cause().printStackTrace();
-
-      }
-    });
-
+    mongoClient.findBatch("book", query)
+      .exceptionHandler(throwable -> throwable.printStackTrace())
+      .endHandler(v -> System.out.println("End of research"))
+      .handler(doc -> System.out.println("Found doc: " + doc.encodePrettily()));
   }
 
 
@@ -537,9 +520,8 @@ public class Examples {
 
       if (res.succeeded()) {
 
-        mongoClient.distinctBatch("books", "title", String.class.getName(), res2 -> {
-          System.out.println("Title is : " + res2.result().getString("title"));
-        });
+        mongoClient.distinctBatch("books", "title", String.class.getName())
+          .handler(book -> System.out.println("Title is : " + book.getString("title")));
 
       } else {
         res.cause().printStackTrace();
@@ -576,9 +558,9 @@ public class Examples {
     mongoClient.save("books", document, res -> {
       if (res.succeeded()) {
 
-        mongoClient.distinctBatchWithQuery("books", "title", String.class.getName(), query, res2 -> {
-          System.out.println("Title is : " + res2.result().getString("title"));
-        });
+        mongoClient.distinctBatchWithQuery("books", "title", String.class.getName(), query)
+          .handler(book -> System.out.println("Title is : " + book.getString("title")));
+
       }
 
     });

--- a/vertx-mongo-client/src/main/java/io/vertx/ext/mongo/MongoClient.java
+++ b/vertx-mongo-client/src/main/java/io/vertx/ext/mongo/MongoClient.java
@@ -1,8 +1,5 @@
 package io.vertx.ext.mongo;
 
-import java.util.List;
-import java.util.UUID;
-
 import io.vertx.codegen.annotations.Fluent;
 import io.vertx.codegen.annotations.VertxGen;
 import io.vertx.core.AsyncResult;
@@ -10,7 +7,11 @@ import io.vertx.core.Handler;
 import io.vertx.core.Vertx;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
+import io.vertx.core.streams.ReadStream;
 import io.vertx.ext.mongo.impl.MongoClientImpl;
+
+import java.util.List;
+import java.util.UUID;
 
 /**
  * A Vert.x service used to interact with MongoDB server instances.
@@ -262,10 +263,8 @@ public interface MongoClient {
    *
    * @param collection  the collection
    * @param query  query used to match documents
-   * @param resultHandler  will be provided with each found document
    */
-  @Fluent
-  MongoClient findBatch(String collection, JsonObject query, Handler<AsyncResult<JsonObject>> resultHandler);
+  ReadStream<JsonObject> findBatch(String collection, JsonObject query);
 
   /**
    * Find matching documents in the specified collection, specifying options
@@ -285,10 +284,8 @@ public interface MongoClient {
    * @param collection  the collection
    * @param query  query used to match documents
    * @param options options to configure the find
-   * @param resultHandler  will be provided with each found document
    */
-  @Fluent
-  MongoClient findBatchWithOptions(String collection, JsonObject query, FindOptions options, Handler<AsyncResult<JsonObject>> resultHandler);
+  ReadStream<JsonObject> findBatchWithOptions(String collection, JsonObject query, FindOptions options);
 
   /**
    * Find a single matching document in the specified collection
@@ -588,10 +585,8 @@ public interface MongoClient {
    *
    * @param collection  the collection
    * @param fieldName  the field name
-   * @param resultHandler  will be provided with each found value
    */
-  @Fluent
-  MongoClient distinctBatch(String collection, String fieldName, String resultClassname, Handler<AsyncResult<JsonObject>> resultHandler);
+  ReadStream<JsonObject> distinctBatch(String collection, String fieldName, String resultClassname);
 
   /**
    * Gets the distinct values of the specified field name filtered by specified query.
@@ -601,10 +596,8 @@ public interface MongoClient {
    * @param collection  the collection
    * @param fieldName  the field name
    * @param query the query
-   * @param resultHandler  will be provided with each found value
    */
-  @Fluent
-  MongoClient distinctBatchWithQuery(String collection, String fieldName, String resultClassname, JsonObject query, Handler<AsyncResult<JsonObject>> resultHandler);
+  ReadStream<JsonObject> distinctBatchWithQuery(String collection, String fieldName, String resultClassname, JsonObject query);
 
   /**
    * Close the client and release its resources

--- a/vertx-mongo-client/src/main/java/io/vertx/ext/mongo/impl/MongoIterableStream.java
+++ b/vertx-mongo-client/src/main/java/io/vertx/ext/mongo/impl/MongoIterableStream.java
@@ -1,0 +1,186 @@
+package io.vertx.ext.mongo.impl;
+
+import com.mongodb.async.AsyncBatchCursor;
+import com.mongodb.async.SingleResultCallback;
+import com.mongodb.async.client.MongoIterable;
+import io.vertx.core.Context;
+import io.vertx.core.Handler;
+import io.vertx.core.json.JsonObject;
+import io.vertx.core.streams.ReadStream;
+
+import java.util.ArrayDeque;
+import java.util.Collections;
+import java.util.Deque;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
+
+/**
+ * @author Thomas Segismont
+ */
+class MongoIterableStream implements ReadStream<JsonObject> {
+
+  private static final int BATCH_SIZE = 10;
+
+  private final Context context;
+  private final MongoIterable<JsonObject> mongoIterable;
+
+  private AsyncBatchCursor<JsonObject> batchCursor;
+  private Deque<JsonObject> queue;
+  private Handler<JsonObject> dataHandler;
+  private Handler<Throwable> exceptionHandler;
+  private Handler<Void> endHandler;
+  private boolean paused;
+  private boolean readInProgress;
+  private boolean closed;
+
+  MongoIterableStream(Context context, MongoIterable<JsonObject> mongoIterable) {
+    this.context = context;
+    this.mongoIterable = mongoIterable;
+  }
+
+  @Override
+  public synchronized MongoIterableStream exceptionHandler(Handler<Throwable> handler) {
+    checkClosed();
+    this.exceptionHandler = handler;
+    return this;
+  }
+
+  private void checkClosed() {
+    if (closed) {
+      throw new IllegalArgumentException("Stream is closed");
+    }
+  }
+
+  @Override
+  public synchronized MongoIterableStream handler(Handler<JsonObject> handler) {
+    checkClosed();
+    if (handler == null) {
+      close();
+    } else {
+      dataHandler = handler;
+      SingleResultCallback<AsyncBatchCursor<JsonObject>> callback = (result, t) -> {
+        context.runOnContext(v -> {
+          synchronized (this) {
+            if (t != null) {
+              close();
+              handleException(t);
+            } else {
+              batchCursor = result;
+              if (canRead()) {
+                doRead();
+              }
+            }
+          }
+        });
+      };
+      try {
+        mongoIterable.batchCursor(callback);
+      } catch (Exception e) {
+        close();
+        handleException(e);
+      }
+    }
+    return this;
+  }
+
+  private boolean canRead() {
+    return !paused && !closed;
+  }
+
+  @Override
+  public synchronized MongoIterableStream pause() {
+    checkClosed();
+    paused = true;
+    return this;
+  }
+
+  @Override
+  public synchronized MongoIterableStream resume() {
+    checkClosed();
+    if (paused) {
+      paused = false;
+      if (dataHandler != null) {
+        doRead();
+      }
+    }
+    return this;
+  }
+
+  private synchronized void doRead() {
+    if (readInProgress) {
+      return;
+    }
+    readInProgress = true;
+    if (queue == null) {
+      queue = new ArrayDeque<>(BATCH_SIZE);
+    }
+    if (!queue.isEmpty()) {
+      context.runOnContext(v -> emitQueued());
+      return;
+    }
+    batchCursor.setBatchSize(BATCH_SIZE);
+    context.<List<JsonObject>>executeBlocking(fut -> {
+      batchCursor.next((result, t) -> {
+        if (t != null) {
+          fut.fail(t);
+        } else {
+          fut.complete(result == null ? Collections.emptyList() : result);
+        }
+      });
+    }, false, ar -> {
+      synchronized (this) {
+        if (ar.succeeded()) {
+          queue.addAll(ar.result());
+          if (queue.isEmpty()) {
+            close();
+            if (endHandler != null) {
+              endHandler.handle(null);
+            }
+          } else {
+            emitQueued();
+          }
+        } else {
+          close();
+          handleException(ar.cause());
+        }
+      }
+    });
+  }
+
+  private void handleException(Throwable cause) {
+    if (exceptionHandler != null) {
+      exceptionHandler.handle(cause);
+    }
+  }
+
+  private synchronized void emitQueued() {
+    while (!queue.isEmpty() && canRead()) {
+      dataHandler.handle(queue.remove());
+    }
+    readInProgress = false;
+    if (canRead()) {
+      doRead();
+    }
+  }
+
+  @Override
+  public synchronized MongoIterableStream endHandler(Handler<Void> handler) {
+    endHandler = handler;
+    return this;
+  }
+
+  private void close() {
+    closed = true;
+    AtomicReference<AsyncBatchCursor> cursorRef = new AtomicReference<>();
+    context.executeBlocking(fut -> {
+      synchronized (this) {
+        cursorRef.set(batchCursor);
+      }
+      AsyncBatchCursor cursor = cursorRef.get();
+      if (cursor != null) {
+        cursor.close();
+      }
+      fut.complete();
+    }, false, null);
+  }
+}

--- a/vertx-mongo-client/src/test/java/io/vertx/ext/mongo/MongoClientTest.java
+++ b/vertx-mongo-client/src/test/java/io/vertx/ext/mongo/MongoClientTest.java
@@ -38,13 +38,10 @@ public class MongoClientTest extends MongoClientTestBase {
     List<String> foos = new ArrayList<>();
     mongoClient.createCollection(collection, onSuccess(res -> {
       insertDocs(mongoClient, collection, numDocs, onSuccess(res2 -> {
-          mongoClient.findBatchWithOptions(collection, new JsonObject(), new FindOptions().setSort(new JsonObject().put("foo", 1)), onSuccess(result -> {
-            if (result == null) {
-              latch.countDown();
-            } else {
-              foos.add(result.getString("foo"));
-            }
-          }));
+        mongoClient.findBatchWithOptions(collection, new JsonObject(), new FindOptions().setSort(new JsonObject().put("foo", 1)))
+          .exceptionHandler(this::fail)
+          .endHandler(v -> latch.countDown())
+          .handler(result -> foos.add(result.getString("foo")));
       }));
     }));
     awaitLatch(latch);

--- a/vertx-mongo-service/src/main/java/io/vertx/ext/mongo/MongoService.java
+++ b/vertx-mongo-service/src/main/java/io/vertx/ext/mongo/MongoService.java
@@ -1,8 +1,7 @@
 package io.vertx.ext.mongo;
 
-import java.util.List;
-
 import io.vertx.codegen.annotations.Fluent;
+import io.vertx.codegen.annotations.GenIgnore;
 import io.vertx.codegen.annotations.ProxyGen;
 import io.vertx.codegen.annotations.ProxyIgnore;
 import io.vertx.codegen.annotations.VertxGen;
@@ -11,7 +10,10 @@ import io.vertx.core.Handler;
 import io.vertx.core.Vertx;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
+import io.vertx.core.streams.ReadStream;
 import io.vertx.serviceproxy.ProxyHelper;
+
+import java.util.List;
 
 /**
  * @author <a href="http://tfox.org">Tim Fox</a>
@@ -99,16 +101,20 @@ public interface MongoService extends MongoClient {
   MongoService find(String collection, JsonObject query, Handler<AsyncResult<List<JsonObject>>> resultHandler);
 
   @Override
-  @Fluent
-  MongoService findBatch(String collection, JsonObject query, Handler<AsyncResult<JsonObject>> resultHandler);
+  @GenIgnore
+  default ReadStream<JsonObject> findBatch(String collection, JsonObject query) {
+    throw new UnsupportedOperationException();
+  }
 
   @Override
   @Fluent
   MongoService findWithOptions(String collection, JsonObject query, FindOptions options, Handler<AsyncResult<List<JsonObject>>> resultHandler);
 
   @Override
-  @Fluent
-  MongoService findBatchWithOptions(String collection, JsonObject query, FindOptions options, Handler<AsyncResult<JsonObject>> resultHandler);
+  @GenIgnore
+  default ReadStream<JsonObject> findBatchWithOptions(String collection, JsonObject query, FindOptions options) {
+    throw new UnsupportedOperationException();
+  }
 
   @Override
   @Fluent
@@ -215,16 +221,20 @@ public interface MongoService extends MongoClient {
   MongoService distinct(String collection, String fieldName, String resultClassname, Handler<AsyncResult<JsonArray>> resultHandler);
 
   @Override
-  @Fluent
-  MongoService distinctBatch(String collection, String fieldName, String resultClassname, Handler<AsyncResult<JsonObject>> resultHandler);
+  @GenIgnore
+  default ReadStream<JsonObject> distinctBatch(String collection, String fieldName, String resultClassname) {
+    throw new UnsupportedOperationException();
+  }
 
   @Override
   @Fluent
   MongoService distinctWithQuery(String collection, String fieldName, String resultClassname, JsonObject query, Handler<AsyncResult<JsonArray>> resultHandler);
 
   @Override
-  @Fluent
-  MongoService distinctBatchWithQuery(String collection, String fieldName, String resultClassname, JsonObject query, Handler<AsyncResult<JsonObject>> resultHandler);
+  @GenIgnore
+  default ReadStream<JsonObject> distinctBatchWithQuery(String collection, String fieldName, String resultClassname, JsonObject query) {
+    throw new UnsupportedOperationException();
+  }
 
   @Override
   @ProxyIgnore

--- a/vertx-mongo-service/src/main/java/io/vertx/ext/mongo/impl/MongoServiceImpl.java
+++ b/vertx-mongo-service/src/main/java/io/vertx/ext/mongo/impl/MongoServiceImpl.java
@@ -1,7 +1,5 @@
 package io.vertx.ext.mongo.impl;
 
-import java.util.List;
-
 import io.vertx.codegen.annotations.Fluent;
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Handler;
@@ -18,6 +16,8 @@ import io.vertx.ext.mongo.MongoClientUpdateResult;
 import io.vertx.ext.mongo.MongoService;
 import io.vertx.ext.mongo.UpdateOptions;
 import io.vertx.ext.mongo.WriteOption;
+
+import java.util.List;
 
 /**
  * @author <a href="http://tfox.org">Tim Fox</a>
@@ -152,23 +152,10 @@ public class MongoServiceImpl implements MongoService {
   }
 
   @Override
-  public MongoService findBatch(String collection, JsonObject query, Handler<AsyncResult<JsonObject>> resultHandler) {
-    client.findBatch(collection, query, resultHandler);
-    return this;
-  }
-
-  @Override
   @Fluent
   public MongoService findWithOptions(String collection, JsonObject query, FindOptions options,
       Handler<AsyncResult<List<JsonObject>>> resultHandler) {
     client.findWithOptions(collection, query, options, resultHandler);
-    return this;
-  }
-
-  @Override
-  public MongoService findBatchWithOptions(String collection, JsonObject query, FindOptions options,
-      Handler<AsyncResult<JsonObject>> resultHandler) {
-    client.findBatchWithOptions(collection, query, options, resultHandler);
     return this;
   }
 
@@ -367,20 +354,6 @@ public class MongoServiceImpl implements MongoService {
   @Override
   public MongoService distinctWithQuery(String collection, String fieldName, String resultClassname, JsonObject query, Handler<AsyncResult<JsonArray>> resultHandler) {
     client.distinctWithQuery(collection, fieldName, resultClassname, query, resultHandler);
-    return this;
-  }
-
-  @Override
-  @Fluent
-  public MongoService distinctBatch(String collection, String fieldName, String resultClassname,
-      Handler<AsyncResult<JsonObject>> resultHandler) {
-    client.distinctBatch(collection, fieldName, resultClassname, resultHandler);
-    return this;
-  }
-
-  @Override
-  public MongoService distinctBatchWithQuery(String collection, String fieldName, String resultClassname, JsonObject query, Handler<AsyncResult<JsonObject>> resultHandler) {
-    client.distinctBatchWithQuery(collection, fieldName, resultClassname, query, resultHandler);
     return this;
   }
 


### PR DESCRIPTION
Fixes #110 

The xxxBatch methods implementation use async result handlers incorrectly: such handlers should be called just once.

Instead, they should return a ReadStream, which brings:
- backpressure support
- RxJava support (via ReadStream.toFlowable)

Note that MongoService cannot implement them since ReadStream are not supported in service proxies.